### PR TITLE
Fix For Issue #206 (Creating a new discussion without selecting a group)

### DIFF
--- a/app/Http/Controllers/GroupDiscussionController.php
+++ b/app/Http/Controllers/GroupDiscussionController.php
@@ -8,14 +8,17 @@ use Auth;
 use Carbon\Carbon;
 use Gate;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 
 class GroupDiscussionController extends Controller
 {
   public function __construct()
   {
+  
     $this->middleware('member', ['only' => ['edit', 'update', 'destroy']]);
     $this->middleware('verified', ['only' => ['create', 'store', 'edit', 'update', 'destroy']]);
     $this->middleware('public', ['only' => ['index', 'show', 'history']]);
+    
   }
 
   /**
@@ -26,7 +29,6 @@ class GroupDiscussionController extends Controller
   public function index(Request $request, Group $group)
   {
     $tags = $group->tagsInDiscussions();
-
 
     $tag = $request->get('tag');
 
@@ -79,18 +81,24 @@ class GroupDiscussionController extends Controller
   */
   public function store(Request $request, Group $group)
   {
-    // if no group is in the route, it means user choose the group using the dropdown
-    if (!$group->exists) {
-      $group = \App\Group::findOrFail($request->get('group'));
+
+    // if no group is in the route, it means user chose the group using the dropdown
+    if (!$group->exists) {      
+        $group = \App\Group::find($request->get('group'));
+        //if group is null, redirect to the discussion create page with error messages, saying
+        //that you must select a group
+        if (is_null($group)) {
+          return redirect()->route('discussions.create')->withErrors(['msg', 'The Message']);
+        }
+    
     }
-
+    
     $this->authorize('creatediscussion', $group);
-
-
+    
     $discussion = new Discussion();
     $discussion->name = $request->input('name');
     $discussion->body = $request->input('body');
-
+   
     $discussion->total_comments = 1; // the discussion itself is already a comment
     $discussion->user()->associate(Auth::user());
 

--- a/app/Http/Controllers/GroupDiscussionController.php
+++ b/app/Http/Controllers/GroupDiscussionController.php
@@ -8,7 +8,7 @@ use Auth;
 use Carbon\Carbon;
 use Gate;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Log;
+
 
 class GroupDiscussionController extends Controller
 {

--- a/app/Http/Controllers/GroupDiscussionController.php
+++ b/app/Http/Controllers/GroupDiscussionController.php
@@ -88,7 +88,7 @@ class GroupDiscussionController extends Controller
         //if group is null, redirect to the discussion create page with error messages, saying
         //that you must select a group
         if (is_null($group)) {
-          return redirect()->route('discussions.create')->withErrors(['msg', 'The Message']);
+          return redirect()->route('discussions.create')->withErrors(['You must select a Group']);
         }
     
     }

--- a/app/Http/Controllers/GroupDiscussionController.php
+++ b/app/Http/Controllers/GroupDiscussionController.php
@@ -98,7 +98,6 @@ class GroupDiscussionController extends Controller
     $discussion = new Discussion();
     $discussion->name = $request->input('name');
     $discussion->body = $request->input('body');
-   
     $discussion->total_comments = 1; // the discussion itself is already a comment
     $discussion->user()->associate(Auth::user());
 

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -56,7 +56,8 @@ return array (
   'create_link_help' => 'Here you can add a link (URL). For example link to videos, shared documents, etc...
   Enter a correct URL starting with http:// and set a title for this link. You can also add tags.',
   'created' => 'Created',
-  'delete' => 'delete',
+  'delete' => 'Delete',
+  'deleteGroup' => 'Delete Group',
   'delete_confirm_button' => 'Delete',
   'delete_confirm_title' => 'Are you sure you want to delete?',
   'description' => 'Description',

--- a/resources/views/groups/tabs.blade.php
+++ b/resources/views/groups/tabs.blade.php
@@ -130,7 +130,7 @@
                     </a>
 
                     <a class="dropdown-item" href="{{ route('groups.deleteconfirm', [$group]) }}">
-                        <i class="fa fa-trash"></i> {{trans('messages.delete')}}
+                        <i class="fa fa-trash"></i> {{trans('messages.deleteGroup')}}
                     </a>
                 </div>
             </li>


### PR DESCRIPTION
Hey Philippe,

This is David. Thanks for corresponding by email with me!

I spent some time yesterday trying to fix issue #206 . The code used Laravel's "findorFail" method if no group was selected. This led the user to an error page.

My changes start on line 85 of GroupDiscussionController.php. Instead of using "findorFail", I just used "find". If "$group" is null, (no group was selected), the user is now sent back to the create discussion page, with a blue error message saying "You must select a Group".