### PR TITLE
Agorakit behind proxies

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -24,7 +24,7 @@ class Kernel extends HttpKernel
      */
     protected $middlewareGroups = [
         'web' => [
-
+			\App\Http\Middleware\TrustProxies::class,
             \App\Http\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -12,7 +12,7 @@ class TrustProxies extends Middleware
      *
      * @var array
      */
-    protected $proxies = env('PROXY_TRUST', ''),;
+    protected $proxies = env('PROXY_TRUST', '');
 
     /**
      * The headers that should be used to detect proxies.

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -12,7 +12,7 @@ class TrustProxies extends Middleware
      *
      * @var array
      */
-    protected $proxies = env('PROXY_TRUST', '');
+    protected $proxies = '*';
 
     /**
      * The headers that should be used to detect proxies.

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -12,7 +12,7 @@ class TrustProxies extends Middleware
      *
      * @var array
      */
-    protected $proxies = '*';
+    protected $proxies = env('PROXY_TRUST', ''),;
 
     /**
      * The headers that should be used to detect proxies.

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Http\Request;
+use Fideloper\Proxy\TrustProxies as Middleware;
+
+class TrustProxies extends Middleware
+{
+    /**
+     * The trusted proxies for this application.
+     *
+     * @var array
+     */
+    protected $proxies = '*';
+
+    /**
+     * The headers that should be used to detect proxies.
+     *
+     * @var string
+     */
+    protected $headers = Request::HEADER_X_FORWARDED_ALL;
+}

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "intervention/imagecache": "2.*",
     "kkomelin/laravel-translatable-string-exporter": "^1.2",
     "kwi/urllinker": "dev-master",
+    "fideloper/proxy": "^4.0",
     "laravel/framework": "5.8.*",
     "laravelcollective/html": "5.8.*",
     "nicolaslopezj/searchable": "^1.10",

--- a/composer.lock
+++ b/composer.lock
@@ -792,6 +792,60 @@
             ],
             "time": "2019-03-17T18:48:37+00:00"
         },
+       {
+            "name": "fideloper/proxy",
+            "version": "4.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fideloper/TrustedProxy.git",
+                "reference": "39a4c2165e578bc771f5dc031c273210a3a9b6d2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fideloper/TrustedProxy/zipball/39a4c2165e578bc771f5dc031c273210a3a9b6d2",
+                "reference": "39a4c2165e578bc771f5dc031c273210a3a9b6d2",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "~5.0|~6.0",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "illuminate/http": "~5.6|~6.0",
+                "mockery/mockery": "~1.0",
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Fideloper\\Proxy\\TrustedProxyServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Fideloper\\Proxy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Fidao",
+                    "email": "fideloper@gmail.com"
+                }
+            ],
+            "description": "Set trusted proxies for Laravel",
+            "keywords": [
+                "load balancing",
+                "proxy",
+                "trusted proxy"
+            ],
+            "time": "2019-07-29T16:49:45+00:00"
+        },
         {
             "name": "geocoder-php/chain-provider",
             "version": "4.0.1",


### PR DESCRIPTION
This is a quick fix for Agorakit working behind a forwarding proxy such as nginx.
There's one thing that needs to be changed that should be trivial for any Laravel-knowedgeable guy (not my case) and it is to replace the hardcoded "*" in the TrustProxies file with the value of a var from the .env file.
