### PR TITLE
Improve mention parsing to avoid breaking URLs

### DIFF
--- a/app/Helpers/Functions.php
+++ b/app/Helpers/Functions.php
@@ -157,3 +157,19 @@ function linkTo($model)
         return route('groups.discussions.show', [$model->group, $model->discussion]);
     }
 }
+
+/**
+ * Whether Unicode support was compiled into PHP's PCRE implementation.
+ *
+ * Unfortunately this isn't possible to detect as a flag inside PHP, so do a quick test.
+ *
+ * @return bool
+ */
+function hasUnicodeSupport(): bool
+{
+    static $unicodeSupport;
+    if (is_null($unicodeSupport)) {
+        $unicodeSupport = (preg_replace("#\pP#u", "", "P") != "");
+    }
+    return $unicodeSupport;
+}

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Illuminate\Foundation\Testing\TestCase;
+
+class FilterTest extends TestCase
+{
+    public static function invalidMentionsProvider(): array
+    {
+        return [
+            ['@@name'],
+            ['@!name'],
+            [' &amp;=@name'],
+            ['.org/path#@name'],
+            ['https://phpc.social/@name/123'],
+            ['https://en.wikipedia.org/wiki/%22@%22_%28album%29'],
+        ];
+    }
+
+    public static function validMentionsProvider(): array
+    {
+        // Do not test entire opening anchor tag to avoid breaking if HTML format changes.
+        return [
+            ['">@name ', '>@name</a>'],
+            ['li>@1name', '>@1name</a>'],
+            ['@name-1', '>@name-1</a>'],
+            ['@__name__', '>@__name__</a>'],
+            ['.@name!', '>@name</a>'],
+            ['(@name, @name2)', '>@name</a>'],
+            ['(@name, @name2)', '>@name2</a>'], // verify both are there.
+        ];
+    }
+
+    #[DataProvider('invalidMentionsProvider')]
+    public function testInvalidMentions(string $input): void
+    {
+        $this->assertEquals($input, highlightMentions($input)); // No changes.
+    }
+
+    #[DataProvider('validMentionsProvider')]
+    public function testValidMentions(string $input, string $needle): void
+    {
+        $parsed = highlightMentions($input);
+        $this->assertStringContainsString($needle, $parsed); // Expected transformations.
+    }
+
+    public function testUnicodeMentions(): void
+    {
+        if (hasUnicodeSupport()) {
+            $this->assertStringContainsString('>@nämé</a>', highlightMentions('>@nämé '));
+        } else {
+            $this->markTestSkipped('Unicode support not available.');
+        }
+    }
+}


### PR DESCRIPTION
Fixes #658 

Adds more robust regex for parsing mentions when rendering content.

Adds helper function `hasUnicodeSupport()` for detecting if we're allowed to use UTF8 support in PCRE.