### PR TITLE
Docker: Copy root CA for local installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ public/mix-manifest.json
 caddy/
 composer/
 psysh/
+.docker/dev/*.crt
 
 # Backup lang files
 resources/lang/*/[a-zA-Z]*20[0-9][0-9][0-1][0-9][0-3][0-9]_[0-2][0-9][0-5][0-9][0-5][0-9].php

--- a/bin/dev-init.sh
+++ b/bin/dev-init.sh
@@ -16,6 +16,11 @@ docker compose -f compose.dev.yml up --build -d
 # Setup app.
 docker exec -it agorakit-dev sh -c "composer install"
 docker exec -it agorakit-dev sh -c "php artisan migrate --env=dev"
+if [ ! -f "./.docker/dev/root.crt" ]; then
+    # Copy CA-signed cert if one was created.
+    echo "Copying CA root cert to ./docker/dev/root.crt for convenience."
+    docker exec -it agorakit-dev sh -c "cp /data/caddy/pki/authorities/local/root.crt /app/.docker/dev/"
+fi
 if [ "$ENV_NEW" = true ]; then
     # Rebuild with new key in ENV (`restart` does not reload ENV).
     echo "Rebuilding container with Laravel key."


### PR DESCRIPTION
This just adds a small convenience: Copy the Docker container's root CA certificate into the repo so that it's easy to find for browser installation.