### PR TITLE
Remove non-UTF-8 characters from calendar JSON (hotfix for app.agorakit.org)

### DIFF
--- a/app/Services/CalendarEventService.php
+++ b/app/Services/CalendarEventService.php
@@ -46,7 +46,7 @@ class CalendarEventService
             $json_events[] = self::calendarEventToFullCalendarJson($event);
         }
 
-        // Properly encode non UTF-8 chars (see https://stackoverflow.com/questions/31115982/malformed-utf-8-characters-possibly-incorrectly-encoded-in-laravel)
+        // Remove non UTF-8 chars (see https://stackoverflow.com/questions/31115982/malformed-utf-8-characters-possibly-incorrectly-encoded-in-laravel)
         return mb_convert_encoding($json_events, 'UTF-8', 'UTF-8');
     }
 }


### PR DESCRIPTION
CalendarEvents taken from the production DB on app.agorakit.org generate "Malformed UTF-8 characters, possibly incorrectly encoded".

The magic conversion to json by laravel (it trigger when you return an array from a controller) seems to not work on app.agorakit.org because some data is not properly encoded as UTF-8.

This quick fix handles it. But I don't like it that much.

Background info : https://stackoverflow.com/questions/46305169/php-json-encode-malformed-utf-8-characters-possibly-incorrectly-encoded