### PR TITLE
Rename calendarevents to events in mail notification (hotfix on agorakit.org)

### DIFF
--- a/app/Console/Commands/SendNotifications.php
+++ b/app/Console/Commands/SendNotifications.php
@@ -160,7 +160,7 @@ class SendNotifications extends Command
 
                 $notification->files = $files;
                 $notification->users = $users;
-                $notification->calendarevents = $events;
+                $notification->events = $events;
                 $notification->last_notification = $last_notification;
 
                 Mail::to($user)->send($notification);


### PR DESCRIPTION
The whole notification system and code organisation need to be reworked, but this small typo must be merged in any case, it blocks notifications on app.agorakit.org