### PR TITLE
Move Docker DB to port 3307

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -42,7 +42,7 @@ services:
         source: ./.docker/dev/mariadb/create-test-db.sh
         target: /docker-entrypoint-initdb.d/create-test-db.sh
     ports:
-      - "3306:3306"
+      - "3307:3306"
     networks:
       - agorakit-development
     healthcheck: # Verifies DB is available to avoid silent failures.


### PR DESCRIPTION
There's no reason (afaik) for the database's Docker container to bind to 3306 on localhost. That is the default for MySQL et. al., which I and presumably many others run locally, meaning it's quite a pain to run these containers if I need to see my other databases at the same time. (I initially thought I could just turn off the localhost and move on, but it's not quite so simple.)

3307 has no special relevance, just ticking +1 to avoid collisions.

This is simpler & lower impact than asking devs to change their localhost setup.

I moved Nitro Porter to 3308 for similar reasons, and was working on https://github.com/prosembler/nitro-porter/pull/97 when I realized I'd need simultaneous access to my existing databases that don't belong in a particular Docker container.