### PR TITLE
Add context to logs

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -33,7 +33,8 @@ class Kernel extends HttpKernel
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \App\Http\Middleware\SetLocale::class,
             \App\Http\Middleware\HandleUserPreference::class,
-            \App\Http\Middleware\LogoutBannedUser::class
+            \App\Http\Middleware\LogoutBannedUser::class,
+            \App\Http\Middleware\AddContextToLogs::class
         ],
 
         'api' => [

--- a/app/Http/Middleware/AddContextToLogs.php
+++ b/app/Http/Middleware/AddContextToLogs.php
@@ -1,0 +1,27 @@
+<?php
+namespace App\Http\Middleware;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Str;
+use Closure;
+use Log;
+
+/**
+ * Adds the user_id, username and path to logs in order to ease debugging bugs in production
+ */
+class AddContextToLogs
+{
+    public function handle(Request $request, Closure $next)
+    {
+        if ($request->user()) {
+            Log::shareContext(array_filter([
+                'user_id' => $request->user()->id,
+                'username' => $request->user()->name,
+                // Add more context here if needed
+            ]));
+        }
+        Log::shareContext(['path' => Str::limit($request->path(), 255)]);
+        return $next($request);
+    }
+}


### PR DESCRIPTION
I often need to debug obscure bugs in production, and having access to the username and request path would tremendously help to trace better the issue.

This PR adds the needed to info to all logs, using a middleware.