### PR TITLE
Remove uneeded logging

### DIFF
--- a/app/Console/Commands/CheckMailbox.php
+++ b/app/Console/Commands/CheckMailbox.php
@@ -444,8 +444,6 @@ class CheckMailbox extends Command
             $user->touch();
             $this->info('Discussion has been created with id : ' . $discussion->id);
             $this->info('Title : ' . $discussion->name);
-            Log::info('Discussion has been created from email', ['mail' => $message, 'discussion' => $discussion]);
-
             $this->moveMessage($message, 'processed');
             return true;
         } else {

--- a/app/Console/Commands/SendNotifications.php
+++ b/app/Console/Commands/SendNotifications.php
@@ -164,8 +164,6 @@ class SendNotifications extends Command
                 $notification->last_notification = $last_notification;
 
                 Mail::to($user)->send($notification);
-                Log::info('User Notified', ['user' => $user]);
-
                 return true;
             }
         }


### PR DESCRIPTION
The logs are full of those info things that just reflect the normal state of the app. This is irrelevant debug information. This pr removes them.