### PR TITLE
Add optional "registration open until" to calendar event

### DIFF
--- a/app/CalendarEvent.php
+++ b/app/CalendarEvent.php
@@ -128,4 +128,14 @@ class CalendarEvent extends Model
     {
         return !is_null($this->registration_open_until);
     }
+
+    public function isRegistrationClosed(\DateTime $now): bool
+    {
+        return !$this->isRegistrationOpen($now);
+    }
+
+    public function isRegistrationOpen(\DateTime $now): bool
+    {
+        return $this->hasRegistrationOpenUntil() && $now <= $this->registration_open_until;
+    }
 }

--- a/app/CalendarEvent.php
+++ b/app/CalendarEvent.php
@@ -36,7 +36,7 @@ class CalendarEvent extends Model
         'stop'     => 'required',
     ];
 
-    protected $fillable = ['id', 'name', 'body', 'start', 'stop', 'visibility', 'location'];
+    protected $fillable = ['id', 'name', 'body', 'start', 'stop', 'visibility', 'location', 'registration_open_until'];
     protected $with = ['attending', 'notAttending']; // always load participants with events
 
     protected $table = 'calendar_events';
@@ -45,7 +45,8 @@ class CalendarEvent extends Model
         'user_id' => 'integer',
         'deleted_at' => 'datetime',
         'start' => 'datetime',
-        'stop' => 'datetime'
+        'stop' => 'datetime',
+        'registration_open_until' => 'datetime'
     ];
 
     protected $keepRevisionOf = ['name', 'start', 'stop', 'body', 'location'];
@@ -121,5 +122,10 @@ class CalendarEvent extends Model
     public function maybeAttending()
     {
         return $this->belongsToMany(User::class)->wherePivot('status', '0');
+    }
+
+    public function hasRegistrationOpenUntil(): bool
+    {
+        return !is_null($this->registration_open_until);
     }
 }

--- a/app/Http/Controllers/GroupCalendarEventController.php
+++ b/app/Http/Controllers/GroupCalendarEventController.php
@@ -223,6 +223,14 @@ class GroupCalendarEventController extends Controller
                 ->withInput();
         }
 
+        try {
+            $event->registration_open_until = $request->date('registration_open_until');
+        } catch (\Exception $e) {
+            return redirect()->route('groups.calendarevents.create', $group)
+                ->withErrors($e->getMessage() . '. Incorrect format in the registration open until date, use date only')
+                ->withInput();
+        }
+
         if ($event->start > $event->stop) {
             return redirect()->route('groups.calendarevents.create', $group)
                 ->withErrors(__('Start date cannot be after end date'))
@@ -371,6 +379,15 @@ class GroupCalendarEventController extends Controller
             $event->stop = Carbon::createFromFormat('Y-m-d H:i', $request->input('stop_date') . ' ' . $request->input('stop_time'));
         } else {
             $event->stop = Carbon::createFromFormat('Y-m-d H:i', $request->input('start_date') . ' ' . $request->input('stop_time'));
+        }
+
+
+        try {
+            $event->registration_open_until = $request->date('registration_open_until');
+        } catch (\Exception $e) {
+            return redirect()->route('groups.calendarevents.create', $group)
+                ->withErrors($e->getMessage() . '. Incorrect format in the registration open until date, use yyyy-mm-dd hh:mm')
+                ->withInput();
         }
 
         // handle location

--- a/app/Http/Controllers/ParticipationController.php
+++ b/app/Http/Controllers/ParticipationController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\CalendarEvent;
 use App\Group;
 use App\Participation;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use URL;
 
@@ -29,6 +30,10 @@ class ParticipationController extends Controller
     {
         $this->authorize('participate', $event);
 
+        if($event->isRegistrationClosed(Carbon::now())) {
+            abort(404, trans('messages.registration_already_closed'));
+        }
+
         $rsvp = Participation::firstOrNew(['user_id' => $request->user()->id, 'calendar_event_id' => $event->id]);
         $rsvp->notification = $request->get('notification');
         $rsvp->status = $request->get('participation');
@@ -44,6 +49,11 @@ class ParticipationController extends Controller
     public function set(Request $request, Group $group, CalendarEvent $event, $status)
     {
         $this->authorize('participate', $event);
+
+        if($event->isRegistrationClosed(Carbon::now())) {
+            abort(400, trans('messages.registration_already_closed'));
+        }
+
         $rsvp = Participation::firstOrNew(['user_id' => $request->user()->id, 'calendar_event_id' => $event->id]);
         //$rsvp->notification = $request->get('notification');
 

--- a/database/migrations/2026_02_24_211943_add_registration_open_until_to_calendar_events.php
+++ b/database/migrations/2026_02_24_211943_add_registration_open_until_to_calendar_events.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('calendar_events', function (Blueprint $table) {
+            $table->timestamp('registration_open_until')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('calendar_events', function (Blueprint $table) {
+            $table->dropColumn('registration_open_until');
+        });
+    }
+};

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -201,6 +201,7 @@ return [
     'regard' => 'Regards',
     'register' => 'Register',
     'registered' => 'Registered',
+    'registration_open_until' => 'Registration open until',
     'registration_time' => 'Registration time',
     'remember_me' => 'Remember me',
     'remove_user' => 'Remove User',

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -201,6 +201,7 @@ return [
     'regard' => 'Regards',
     'register' => 'Register',
     'registered' => 'Registered',
+    'registration_already_closed' => 'Registration already closed',
     'registration_open_until' => 'Registration open until',
     'registration_time' => 'Registration time',
     'remember_me' => 'Remember me',

--- a/resources/views/calendarevents/form.blade.php
+++ b/resources/views/calendarevents/form.blade.php
@@ -72,3 +72,8 @@
         {!! Form::date('stop_date', null, ['class' => 'form-control']) !!}
     @endif
 </div>
+
+<div class="form-group">
+    {!! Form::label('registration_open_until', trans('messages.registration_open_until')) !!}
+    {!! Form::date('registration_open_until', $event->hasRegistrationOpenUntil() ? $event->registration_open_until->format('Y-m-d') : null, ['class' => 'form-control']) !!}
+</div>

--- a/resources/views/calendarevents/show.blade.php
+++ b/resources/views/calendarevents/show.blade.php
@@ -55,6 +55,11 @@
             @if ($event->stop > $event->start) <h3>{{ trans('messages.ends') }} : {{ $event->stop->isoFormat('LLLL') }}</h3>
             @endif
 
+            @if ($event->hasRegistrationOpenUntil())
+                <div class="fw-bold">{{ trans('messages.registration_open_until') }}</div>
+                {{ $event->registration_open_until->isoFormat('LLLL') }}
+            @endif
+
             @if ($event->hasLocation())
                 <div class="fw-bold">{{ trans('messages.location') }}</div>
                 {{ $event->locationDisplay("long") }}

--- a/resources/views/participation/dropdown.blade.php
+++ b/resources/views/participation/dropdown.blade.php
@@ -1,34 +1,40 @@
 @auth
-    <div class="participate-dropdown">
-        <button aria-expanded="false" aria-haspopup="true" class="btn btn-outline-primary dropdown-toggle"
-            data-bs-toggle="dropdown" id="dropdownMenuButton" type="button">
-            @if (Auth::user()->isAttending($event))
-                <i class="fa fa-calendar-check-o me-2"></i> {{ __('I will participate') }}
-            @elseif (Auth::user()->isNotAttending($event))
-                <i class="fa fa-calendar-times-o me-2"></i> {{ __('I will not participate') }}
-            @else
-                <i class="fa fa-question-circle-o me-2"></i> {{ __('I don\'t know yet') }}
-            @endif
-        </button>
-        <div aria-labelledby="dropdownMenuButton" class="dropdown-menu">
-            <a class="dropdown-item"
-                href="{{ route('groups.calendarevents.participation.set', ['group' => $event->group, 'event' => $event, 'status' => 'yes']) }}"
-                up-cache="false" up-history="false" up-target="#participate-{{ $event->id }}">
-                {{ __('I will participate') }}
-            </a>
+    @if($event->isRegistrationOpen(Carbon\Carbon::now()))
+        <div class="participate-dropdown">
+            <button aria-expanded="false" aria-haspopup="true" class="btn btn-outline-primary dropdown-toggle"
+                    data-bs-toggle="dropdown" id="dropdownMenuButton" type="button">
+                @if (Auth::user()->isAttending($event))
+                    <i class="fa fa-calendar-check-o me-2"></i> {{ __('I will participate') }}
+                @elseif (Auth::user()->isNotAttending($event))
+                    <i class="fa fa-calendar-times-o me-2"></i> {{ __('I will not participate') }}
+                @else
+                    <i class="fa fa-question-circle-o me-2"></i> {{ __('I don\'t know yet') }}
+                @endif
+            </button>
+            <div aria-labelledby="dropdownMenuButton" class="dropdown-menu">
+                <a class="dropdown-item"
+                   href="{{ route('groups.calendarevents.participation.set', ['group' => $event->group, 'event' => $event, 'status' => 'yes']) }}"
+                   up-cache="false" up-history="false" up-target="#participate-{{ $event->id }}">
+                    {{ __('I will participate') }}
+                </a>
 
-            <a class="dropdown-item"
-                href="{{ route('groups.calendarevents.participation.set', ['group' => $event->group, 'event' => $event, 'status' => 'no']) }}"
-                up-cache="false" up-history="false" up-target="#participate-{{ $event->id }}">
-                {{ __('I will not participate') }}
-            </a>
+                <a class="dropdown-item"
+                   href="{{ route('groups.calendarevents.participation.set', ['group' => $event->group, 'event' => $event, 'status' => 'no']) }}"
+                   up-cache="false" up-history="false" up-target="#participate-{{ $event->id }}">
+                    {{ __('I will not participate') }}
+                </a>
 
-            <a class="dropdown-item"
-                href="{{ route('groups.calendarevents.participation.set', ['group' => $event->group, 'event' => $event, 'status' => 'maybe']) }}"
-                up-cache="false" up-history="false" up-target="#participate-{{ $event->id }}">
-                {{ __('I don\'t know yet') }}
-            </a>
+                <a class="dropdown-item"
+                   href="{{ route('groups.calendarevents.participation.set', ['group' => $event->group, 'event' => $event, 'status' => 'maybe']) }}"
+                   up-cache="false" up-history="false" up-target="#participate-{{ $event->id }}">
+                    {{ __('I don\'t know yet') }}
+                </a>
 
+            </div>
         </div>
-    </div>
+    @else
+        <p>
+            {!! trans('messages.registration_already_closed') !!}
+        </p>
+    @endif
 @endauth

--- a/tests/e2e/CalendarEventTest.php
+++ b/tests/e2e/CalendarEventTest.php
@@ -31,6 +31,27 @@ class CalendarEventTest extends BaseTest
             ->see(trans('messages.ressource_created_successfully'));
     }
 
+    public function testEventWithRegistrationOpenUntil()
+    {
+        $user = $this->admin();
+        $group = $this->getTestGroup();
+
+        $this->actingAs($user)
+            ->visit('/groups/' . $group->id . '/calendarevents/create')
+            ->see('Add an event')
+            ->type('Test event with registration open until', 'name')
+            ->type('this is a test event in the calendar', 'body')
+            ->type('2026-01-01', 'start_date')
+            ->type('12:00', 'start_time')
+            ->type('2025-12-25', 'registration_open_until')
+            ->press('Create')
+            ->seeInDatabase('calendar_events', [
+                'name' => 'Test event with registration open until',
+                'registration_open_until' => '2025-12-25'
+            ])
+            ->see(trans('messages.ressource_created_successfully'));
+    }
+
     public function testEventWithWrongStopTimeCreation()
     {
         $user = $this->admin();


### PR DESCRIPTION
As a result from the discussion in #700 I added an optional field to the calendar event for the registration deadline.
As I could not obtain the translate.io API key I will add the translation keys in the web interface of translation.io.